### PR TITLE
Supported arbitrary code page to avoid garbled results in some fields

### DIFF
--- a/Lnk/ExtraData/DarwinDataBlock.cs
+++ b/Lnk/ExtraData/DarwinDataBlock.cs
@@ -10,14 +10,14 @@ public class DarwinDataBlock : ExtraDataBase
     private const string Base85 =
         "!$%&'()*+,-.0123456789=?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{}~";
 
-    public DarwinDataBlock(byte[] rawBytes)
+    public DarwinDataBlock(byte[] rawBytes, int codepage=1252)
     {
         Signature = ExtraDataTypes.DarwinDataBlock;
 
         Size = BitConverter.ToUInt32(rawBytes, 0);
 
         //TODO can these be decoded further?
-        ApplicationIdentifierAscii = CodePagesEncodingProvider.Instance.GetEncoding(1252)?.GetString(rawBytes, 8, 260).Split('\0').First();
+        ApplicationIdentifierAscii = CodePagesEncodingProvider.Instance.GetEncoding(codepage)?.GetString(rawBytes, 8, 260).Split('\0').First();
         ApplicationIdentifierUnicode = Encoding.Unicode.GetString(rawBytes, 268, 520).Split('\0').First();
 
         var sepChar = '>';

--- a/Lnk/ExtraData/EnvironmentVariableDataBlock.cs
+++ b/Lnk/ExtraData/EnvironmentVariableDataBlock.cs
@@ -6,13 +6,13 @@ namespace Lnk.ExtraData;
 
 public class EnvironmentVariableDataBlock : ExtraDataBase
 {
-    public EnvironmentVariableDataBlock(byte[] rawBytes)
+    public EnvironmentVariableDataBlock(byte[] rawBytes, int codepage=1252)
     {
         Signature = ExtraDataTypes.EnvironmentVariableDataBlock;
 
         Size = BitConverter.ToUInt32(rawBytes, 0);
 
-        EnvironmentVariablesAscii = CodePagesEncodingProvider.Instance.GetEncoding(1252).GetString(rawBytes, 8, 260).Split('\0').First();
+        EnvironmentVariablesAscii = CodePagesEncodingProvider.Instance.GetEncoding(codepage).GetString(rawBytes, 8, 260).Split('\0').First();
         EnvironmentVariablesUnicode = Encoding.Unicode.GetString(rawBytes, 268, 520).Split('\0').First();
     }
 

--- a/Lnk/ExtraData/IconEnvironmentDataBlock.cs
+++ b/Lnk/ExtraData/IconEnvironmentDataBlock.cs
@@ -6,13 +6,13 @@ namespace Lnk.ExtraData;
 
 public class IconEnvironmentDataBlock : ExtraDataBase
 {
-    public IconEnvironmentDataBlock(byte[] rawBytes)
+    public IconEnvironmentDataBlock(byte[] rawBytes, int codepage)
     {
         Signature = ExtraDataTypes.IconEnvironmentDataBlock;
 
         Size = BitConverter.ToUInt32(rawBytes, 0);
 
-        IconPathAscii = CodePagesEncodingProvider.Instance.GetEncoding(1252).GetString(rawBytes, 8, 260).Split('\0').First();
+        IconPathAscii = CodePagesEncodingProvider.Instance.GetEncoding(codepage).GetString(rawBytes, 8, 260).Split('\0').First();
         IconPathUni = Encoding.Unicode.GetString(rawBytes, 268, 520).Split('\0').First();
     }
 

--- a/Lnk/ExtraData/TrackerDataBaseBlock.cs
+++ b/Lnk/ExtraData/TrackerDataBaseBlock.cs
@@ -7,13 +7,13 @@ namespace Lnk.ExtraData;
 
 public class TrackerDataBaseBlock : ExtraDataBase
 {
-    public TrackerDataBaseBlock(byte[] rawBytes)
+    public TrackerDataBaseBlock(byte[] rawBytes, int codepage=1252)
     {
         Size = BitConverter.ToUInt32(rawBytes, 0);
 
         Signature = ExtraDataTypes.TrackerDataBlock;
         Version = BitConverter.ToInt32(rawBytes, 8);
-        MachineId = CodePagesEncodingProvider.Instance.GetEncoding(1252).GetString(rawBytes, 16, 16).Split('\0').First();
+        MachineId = CodePagesEncodingProvider.Instance.GetEncoding(codepage).GetString(rawBytes, 16, 16).Split('\0').First();
 
         var guidRaw0 = new byte[16];
         var guidRaw1 = new byte[16];

--- a/Lnk/ExtraData/VistaAndAboveIDListDataBlock.cs
+++ b/Lnk/ExtraData/VistaAndAboveIDListDataBlock.cs
@@ -7,7 +7,7 @@ namespace Lnk.ExtraData;
 
 public class VistaAndAboveIdListDataBlock : ExtraDataBase
 {
-    public VistaAndAboveIdListDataBlock(byte[] rawBytes)
+    public VistaAndAboveIdListDataBlock(byte[] rawBytes, int codepage=1252)
     {
         Signature = ExtraDataTypes.VistaAndAboveIdListDataBlock;
 
@@ -46,12 +46,12 @@ public class VistaAndAboveIdListDataBlock : ExtraDataBase
             switch (bytese[2])
             {
                 case 0x1f:
-                    var f = new ShellBag0X1F(bytese);
+                    var f = new ShellBag0X1F(bytese, codepage);
                     TargetIDs.Add(f);
                     break;
 
                 case 0x2f:
-                    var ff = new ShellBag0X2F(bytese);
+                    var ff = new ShellBag0X2F(bytese, codepage);
                     TargetIDs.Add(ff);
                     break;
                 case 0x2e:
@@ -61,11 +61,11 @@ public class VistaAndAboveIdListDataBlock : ExtraDataBase
                 case 0xb1:
                 case 0x31:
                 case 0x35:
-                    var d = new ShellBag0X31(bytese);
+                    var d = new ShellBag0X31(bytese, codepage);
                     TargetIDs.Add(d);
                     break;
                 case 0x32:
-                    var d2 = new ShellBag0X32(bytese);
+                    var d2 = new ShellBag0X32(bytese, codepage);
                     TargetIDs.Add(d2);
                     break;
                 case 0x00:
@@ -81,18 +81,18 @@ public class VistaAndAboveIdListDataBlock : ExtraDataBase
                     TargetIDs.Add(sevenone);
                     break;
                 case 0x61:
-                    var sixone = new ShellBag0X61(bytese);
+                    var sixone = new ShellBag0X61(bytese, codepage);
                     TargetIDs.Add(sixone);
                     break;
 
                 case 0xC3:
-                    var c3 = new ShellBag0Xc3(bytese);
+                    var c3 = new ShellBag0Xc3(bytese, codepage);
                     TargetIDs.Add(c3);
                     break;
 
                 case 0x74:
                 case 0x77:
-                    var sev = new ShellBag0X74(bytese);
+                    var sev = new ShellBag0X74(bytese, codepage);
                     TargetIDs.Add(sev);
                     break;
 
@@ -101,7 +101,7 @@ public class VistaAndAboveIdListDataBlock : ExtraDataBase
                 case 0x43:
                 case 0x46:
                 case 0x47:
-                    var forty = new ShellBag0X40(bytese);
+                    var forty = new ShellBag0X40(bytese, codepage);
                     TargetIDs.Add(forty);
                     break;
                 default:

--- a/Lnk/Lnk.cs
+++ b/Lnk/Lnk.cs
@@ -11,7 +11,7 @@ public static class Lnk
     /// <param name="lnkFile"></param>
     /// <returns>LnkFile</returns>
     /// <exception cref="Exception"></exception>
-    public static LnkFile LoadFile(string lnkFile)
+    public static LnkFile LoadFile(string lnkFile, int codepage=1252)
     {
         var raw = File.ReadAllBytes(lnkFile);
 
@@ -20,6 +20,6 @@ public static class Lnk
             throw new Exception($"Invalid signature!");
         }
 
-        return new LnkFile(raw, lnkFile);
+        return new LnkFile(raw, lnkFile, codepage);
     }
 }

--- a/Lnk/LnkFile.cs
+++ b/Lnk/LnkFile.cs
@@ -19,7 +19,7 @@ public class LnkFile
         [Description("The linked file is on a network share")] CommonNetworkRelativeLinkAndPathSuffix = 0x0002
     }
 
-    public LnkFile(byte[] rawBytes, string sourceFile)
+    public LnkFile(byte[] rawBytes, string sourceFile, int codepage=1252)
     {
         RawBytes = rawBytes;
         SourceFile = Path.GetFullPath(sourceFile);
@@ -107,17 +107,17 @@ public class LnkFile
                 switch (shellItem[2])
                 {
                     case 0x1f:
-                        var f = new ShellBag0X1F(shellItem);
+                        var f = new ShellBag0X1F(shellItem, codepage);
                         TargetIDs.Add(f);
                         break;
                     case 0x22:
                     case 0x23:
-                        var two3 = new ShellBag0X23(shellItem);
+                        var two3 = new ShellBag0X23(shellItem, codepage);
                         TargetIDs.Add(two3);
                         break;
                     case 0x2a:
                     case 0x2f:
-                        var ff = new ShellBag0X2F(shellItem);
+                        var ff = new ShellBag0X2F(shellItem, codepage);
                         TargetIDs.Add(ff);
                         break;
                     case 0x2e:
@@ -130,17 +130,17 @@ public class LnkFile
                     case 0x3A:
                     case 0x35:
                     case 0x39:
-                        var d = new ShellBag0X31(shellItem);
+                        var d = new ShellBag0X31(shellItem, codepage);
                         TargetIDs.Add(d);
                         break;
                         
                     case 0x32:
                     case 0x36:
-                        var d2 = new ShellBag0X32(shellItem);
+                        var d2 = new ShellBag0X32(shellItem, codepage);
                         TargetIDs.Add(d2);
                         break;
                     case 0x00:
-                        var v0 = new ShellBag0X00(shellItem);
+                        var v0 = new ShellBag0X00(shellItem, codepage);
                         TargetIDs.Add(v0);
                         break;
                     case 0x01:
@@ -152,18 +152,18 @@ public class LnkFile
                         TargetIDs.Add(sevenone);
                         break;
                     case 0x61:
-                        var sixone = new ShellBag0X61(shellItem);
+                        var sixone = new ShellBag0X61(shellItem, codepage);
                         TargetIDs.Add(sixone);
                         break;
 
                     case 0xC3:
-                        var c3 = new ShellBag0Xc3(shellItem);
+                        var c3 = new ShellBag0Xc3(shellItem, codepage);
                         TargetIDs.Add(c3);
                         break;
 
                     case 0x74:
                     case 0x77:
-                        var sev = new ShellBag0X74(shellItem);
+                        var sev = new ShellBag0X74(shellItem, codepage);
                         TargetIDs.Add(sev);
                         break;
 
@@ -179,7 +179,7 @@ public class LnkFile
                     case 0x43:
                     case 0x46:
                     case 0x47:
-                        var forty = new ShellBag0X40(shellItem);
+                        var forty = new ShellBag0X40(shellItem, codepage);
                         TargetIDs.Add(forty);
                         break;
                     case 0x4C:
@@ -216,7 +216,7 @@ public class LnkFile
 
                 if (volOffset > 0)
                 {
-                    VolumeInfo = new VolumeInfo(volBytes);
+                    VolumeInfo = new VolumeInfo(volBytes, codepage);
                 }
 
                 var localPathOffset = BitConverter.ToInt32(locationBytes, 16);
@@ -225,7 +225,7 @@ public class LnkFile
                 if ((LocationFlags & LocationFlag.VolumeIdAndLocalBasePath) ==
                     LocationFlag.VolumeIdAndLocalBasePath)
                 {
-                    LocalPath = CodePagesEncodingProvider.Instance.GetEncoding(1252)
+                    LocalPath = CodePagesEncodingProvider.Instance.GetEncoding(codepage)
                         .GetString(locationBytes, localPathOffset, locationBytes.Length - localPathOffset)
                         .Split('\0')
                         .First();
@@ -237,12 +237,12 @@ public class LnkFile
                     var networkBytes = new byte[networkShareSize];
                     Buffer.BlockCopy(locationBytes, networkShareOffset, networkBytes, 0, networkShareSize);
 
-                    NetworkShareInfo = new NetworkShareInfo(networkBytes);
+                    NetworkShareInfo = new NetworkShareInfo(networkBytes, codepage);
                 }
 
                 var commonPathOffset = BitConverter.ToInt32(locationBytes, 24);
 
-                CommonPath = CodePagesEncodingProvider.Instance.GetEncoding(1252)
+                CommonPath = CodePagesEncodingProvider.Instance.GetEncoding(codepage)
                     .GetString(locationBytes, commonPathOffset, locationBytes.Length - commonPathOffset)
                     .Split('\0')
                     .First();
@@ -285,7 +285,7 @@ public class LnkFile
             }
             else
             {
-                Name = CodePagesEncodingProvider.Instance.GetEncoding(1252).GetString(rawBytes, index, nameLen);
+                Name = CodePagesEncodingProvider.Instance.GetEncoding(codepage).GetString(rawBytes, index, nameLen);
             }
             index += nameLen;
         }
@@ -301,7 +301,7 @@ public class LnkFile
             }
             else
             {
-                RelativePath = CodePagesEncodingProvider.Instance.GetEncoding(1252).GetString(rawBytes, index, relLen);
+                RelativePath = CodePagesEncodingProvider.Instance.GetEncoding(codepage).GetString(rawBytes, index, relLen);
             }
             index += relLen;
         }
@@ -317,7 +317,7 @@ public class LnkFile
             }
             else
             {
-                WorkingDirectory = CodePagesEncodingProvider.Instance.GetEncoding(1252).GetString(rawBytes, index, workLen);
+                WorkingDirectory = CodePagesEncodingProvider.Instance.GetEncoding(codepage).GetString(rawBytes, index, workLen);
             }
             index += workLen;
         }
@@ -333,7 +333,7 @@ public class LnkFile
             }
             else
             {
-                Arguments = CodePagesEncodingProvider.Instance.GetEncoding(1252).GetString(rawBytes, index, argLen);
+                Arguments = CodePagesEncodingProvider.Instance.GetEncoding(codepage).GetString(rawBytes, index, argLen);
             }
             index += argLen;
         }
@@ -349,7 +349,7 @@ public class LnkFile
             }
             else
             {
-                IconLocation = CodePagesEncodingProvider.Instance.GetEncoding(1252).GetString(rawBytes, index, icoLen);
+                IconLocation = CodePagesEncodingProvider.Instance.GetEncoding(codepage).GetString(rawBytes, index, icoLen);
             }
             index += icoLen;
         }
@@ -389,7 +389,7 @@ public class LnkFile
                 switch (sig)
                 {
                     case ExtraDataTypes.TrackerDataBlock:
-                        var tb = new TrackerDataBaseBlock(extraBlock);
+                        var tb = new TrackerDataBaseBlock(extraBlock, codepage);
                         ExtraBlocks.Add(tb);
                         break;
                     case ExtraDataTypes.ConsoleDataBlock:
@@ -401,15 +401,15 @@ public class LnkFile
                         ExtraBlocks.Add(cfeb);
                         break;
                     case ExtraDataTypes.DarwinDataBlock:
-                        var db = new DarwinDataBlock(extraBlock);
+                        var db = new DarwinDataBlock(extraBlock, codepage);
                         ExtraBlocks.Add(db);
                         break;
                     case ExtraDataTypes.EnvironmentVariableDataBlock:
-                        var eb = new EnvironmentVariableDataBlock(extraBlock);
+                        var eb = new EnvironmentVariableDataBlock(extraBlock, codepage);
                         ExtraBlocks.Add(eb);
                         break;
                     case ExtraDataTypes.IconEnvironmentDataBlock:
-                        var ib = new IconEnvironmentDataBlock(extraBlock);
+                        var ib = new IconEnvironmentDataBlock(extraBlock, codepage);
                         ExtraBlocks.Add(ib);
                         break;
                     case ExtraDataTypes.KnownFolderDataBlock:
@@ -430,7 +430,7 @@ public class LnkFile
                         ExtraBlocks.Add(sf);
                         break;
                     case ExtraDataTypes.VistaAndAboveIdListDataBlock:
-                        var vid = new VistaAndAboveIdListDataBlock(extraBlock);
+                        var vid = new VistaAndAboveIdListDataBlock(extraBlock, codepage);
                         ExtraBlocks.Add(vid);
                         break;
                     default:

--- a/Lnk/NetworkShareInfo.cs
+++ b/Lnk/NetworkShareInfo.cs
@@ -84,7 +84,7 @@ public class NetworkShareInfo
         [Description("If set, the network provider type contains data")] ValidNetType = 0x0002
     }
 
-    public NetworkShareInfo(byte[] rawBytes)
+    public NetworkShareInfo(byte[] rawBytes, int codepage=1252)
     {
         Size = BitConverter.ToInt32(rawBytes, 0);
         ShareFlags = (ShareFlag) BitConverter.ToInt32(rawBytes, 4);
@@ -111,7 +111,7 @@ public class NetworkShareInfo
         }
         else
         {
-            NetworkShareName = CodePagesEncodingProvider.Instance.GetEncoding(1252)
+            NetworkShareName = CodePagesEncodingProvider.Instance.GetEncoding(codepage)
                 .GetString(rawBytes, NetworkShareNameOffset, rawBytes.Length - NetworkShareNameOffset)
                 .Split('\0')
                 .First();
@@ -119,7 +119,7 @@ public class NetworkShareInfo
             DeviceName = string.Empty;
             if (DeviceNameOffset > 0)
             {
-                DeviceName = CodePagesEncodingProvider.Instance.GetEncoding(1252)
+                DeviceName = CodePagesEncodingProvider.Instance.GetEncoding(codepage)
                     .GetString(rawBytes, DeviceNameOffset, rawBytes.Length - DeviceNameOffset)
                     .Split('\0')
                     .First();

--- a/Lnk/ShellItems/ShellBag0X23.cs
+++ b/Lnk/ShellItems/ShellBag0X23.cs
@@ -8,7 +8,7 @@ namespace Lnk.ShellItems;
 
 public class ShellBag0X23 : ShellBag
 {
-    public ShellBag0X23(byte[] rawBytes)
+    public ShellBag0X23(byte[] rawBytes, int codepage=1252)
     {
 
         FriendlyName = "Drive letter";
@@ -16,7 +16,7 @@ public class ShellBag0X23 : ShellBag
         ExtensionBlocks = new List<IExtensionBlock>();
 
 
-        var driveLetter = CodePagesEncodingProvider.Instance.GetEncoding(1252).GetString(rawBytes, 3, 2);
+        var driveLetter = CodePagesEncodingProvider.Instance.GetEncoding(codepage).GetString(rawBytes, 3, 2);
 
         Value = driveLetter;
 

--- a/Lnk/ShellItems/ShellBag0x00.cs
+++ b/Lnk/ShellItems/ShellBag0x00.cs
@@ -18,7 +18,7 @@ public class ShellBag0X00 : ShellBag
     private string _storageIdName;
 
 
-    public ShellBag0X00(byte[] rawBytes)
+    public ShellBag0X00(byte[] rawBytes, int codepage=1252)
     {
         _guids = new List<string>();
 
@@ -80,7 +80,7 @@ public class ShellBag0X00 : ShellBag
             case 0x00030005:
             case 0x00000005:
 
-                ProcessFtpSubItem(rawBytes);
+                ProcessFtpSubItem(rawBytes, codepage);
 
                 break;
             case 0x23febbee:
@@ -116,7 +116,7 @@ public class ShellBag0X00 : ShellBag
                 }
                 else
                 {
-                    ProcessPropertyViewDefault(rawBytes);
+                    ProcessPropertyViewDefault(rawBytes, codepage);
                 }
 
                 break;
@@ -177,7 +177,7 @@ public class ShellBag0X00 : ShellBag
         FullUrl = url.Replace("\0", "");
     }
 
-    private void ProcessFtpSubItem(byte[] rawBytes)
+    private void ProcessFtpSubItem(byte[] rawBytes, int codepage=1252)
     {
         FriendlyName = "Variable: FTP URI";
 
@@ -203,7 +203,7 @@ public class ShellBag0X00 : ShellBag
             len1 += 1;
         }
 
-        var s1 = CodePagesEncodingProvider.Instance.GetEncoding(1252).GetString(rawBytes, index, len1);
+        var s1 = CodePagesEncodingProvider.Instance.GetEncoding(codepage).GetString(rawBytes, index, len1);
 
         ShortName = s1;
 
@@ -404,7 +404,7 @@ public class ShellBag0X00 : ShellBag
         }
     }
 
-    private void ProcessPropertyViewDefault(byte[] rawBytes)
+    private void ProcessPropertyViewDefault(byte[] rawBytes, int codepage=1252)
     {
         FriendlyName = "Variable: Users property view";
         var index = 10;
@@ -421,7 +421,7 @@ public class ShellBag0X00 : ShellBag
         {
             index = 0xc;
 
-            var strs = CodePagesEncodingProvider.Instance.GetEncoding(1252).GetString(rawBytes, index, rawBytes.Length - index).Split('\0');
+            var strs = CodePagesEncodingProvider.Instance.GetEncoding(codepage).GetString(rawBytes, index, rawBytes.Length - index).Split('\0');
 
             var p2 = string.Join(",", strs.Skip(1).ToList());
 
@@ -509,7 +509,7 @@ public class ShellBag0X00 : ShellBag
 
             if (rawBytes[4] == 0x41 && rawBytes[5] == 0x75 && rawBytes[6] == 0x67 && rawBytes[7] == 0x4D)
             {
-                var cdb = new ShellBagCDBurn(rawBytes);
+                var cdb = new ShellBagCDBurn(rawBytes, codepage);
 
                 Value = cdb.Value;
                 FriendlyName = cdb.FriendlyName;

--- a/Lnk/ShellItems/ShellBag0x1f.cs
+++ b/Lnk/ShellItems/ShellBag0x1f.cs
@@ -14,7 +14,7 @@ public class ShellBag0X1F : ShellBag
     private readonly List<PropertySheet> Sheets;
 
 
-    public ShellBag0X1F(byte[] rawBytes)
+    public ShellBag0X1F(byte[] rawBytes, int codepage=1252)
     {
         ExtensionBlocks = new List<IExtensionBlock>();
 
@@ -34,7 +34,7 @@ public class ShellBag0X1F : ShellBag
         {
             index = 13;
 
-            var dl = CodePagesEncodingProvider.Instance.GetEncoding(1252).GetString(rawBytes, index, 3);
+            var dl = CodePagesEncodingProvider.Instance.GetEncoding(codepage).GetString(rawBytes, index, 3);
 
             FriendlyName = "Users property view: Drive letter";
 

--- a/Lnk/ShellItems/ShellBag0x2f.cs
+++ b/Lnk/ShellItems/ShellBag0x2f.cs
@@ -8,13 +8,13 @@ namespace Lnk.ShellItems;
 
 public class ShellBag0X2F : ShellBag
 {
-    public ShellBag0X2F(byte[] rawBytes)
+    public ShellBag0X2F(byte[] rawBytes, int codepage=1252)
     {
         FriendlyName = "Drive letter";
 
         ExtensionBlocks = new List<IExtensionBlock>();
 
-        var driveLetter = CodePagesEncodingProvider.Instance.GetEncoding(1252).GetString(rawBytes, 3, 2);
+        var driveLetter = CodePagesEncodingProvider.Instance.GetEncoding(codepage).GetString(rawBytes, 3, 2);
 
         Value = driveLetter;
 

--- a/Lnk/ShellItems/ShellBag0x31.cs
+++ b/Lnk/ShellItems/ShellBag0x31.cs
@@ -9,7 +9,7 @@ namespace Lnk.ShellItems;
 
 public class ShellBag0X31 : ShellBag
 {
-    public ShellBag0X31(byte[] rawBytes)
+    public ShellBag0X31(byte[] rawBytes, int codepage=1252)
     {
         FriendlyName = "Directory";
 
@@ -105,7 +105,7 @@ public class ShellBag0X31 : ShellBag
         }
         else
         {
-            shortName = CodePagesEncodingProvider.Instance.GetEncoding(1252).GetString(tempBytes).Trim('\0');
+            shortName = CodePagesEncodingProvider.Instance.GetEncoding(codepage).GetString(tempBytes).Trim('\0');
         }
 
         ShortName = shortName;

--- a/Lnk/ShellItems/ShellBag0x32.cs
+++ b/Lnk/ShellItems/ShellBag0x32.cs
@@ -8,7 +8,7 @@ namespace Lnk.ShellItems;
 
 public class ShellBag0X32 : ShellBag
 {
-    public ShellBag0X32(byte[] rawBytes)
+    public ShellBag0X32(byte[] rawBytes, int codepage=1252)
     {
         FriendlyName = "File";
 
@@ -81,7 +81,7 @@ public class ShellBag0X32 : ShellBag
 
         if (beefPos == 0)
         {
-            var hackName = CodePagesEncodingProvider.Instance.GetEncoding(1252).GetString(rawBytes, index, rawBytes.Length - index);
+            var hackName = CodePagesEncodingProvider.Instance.GetEncoding(codepage).GetString(rawBytes, index, rawBytes.Length - index);
 
             var segs = hackName.Split(new[] {'\0'}, StringSplitOptions.RemoveEmptyEntries);
 
@@ -118,7 +118,7 @@ public class ShellBag0X32 : ShellBag
         }
         else
         {
-            shortName = CodePagesEncodingProvider.Instance.GetEncoding(1252).GetString(tempBytes);
+            shortName = CodePagesEncodingProvider.Instance.GetEncoding(codepage).GetString(tempBytes);
         }
 
         ShortName = shortName;

--- a/Lnk/ShellItems/ShellBag0x40.cs
+++ b/Lnk/ShellItems/ShellBag0x40.cs
@@ -8,7 +8,7 @@ public class ShellBag0X40 : ShellBag
 {
     private string _desc;
 
-    public ShellBag0X40(byte[] rawBytes)
+    public ShellBag0X40(byte[] rawBytes, int codepage=1252)
     {
         ExtensionBlocks = new List<IExtensionBlock>();
 
@@ -38,7 +38,7 @@ public class ShellBag0X40 : ShellBag
         }
 
 
-        var temp = CodePagesEncodingProvider.Instance.GetEncoding(1252).GetString(rawBytes, 5, rawBytes.Length - 5).Split('\0');
+        var temp = CodePagesEncodingProvider.Instance.GetEncoding(codepage).GetString(rawBytes, 5, rawBytes.Length - 5).Split('\0');
 
         _desc = temp[1];
 

--- a/Lnk/ShellItems/ShellBag0x61.cs
+++ b/Lnk/ShellItems/ShellBag0x61.cs
@@ -14,7 +14,7 @@ public class ShellBag0X61 : ShellBag
     // Fields...
 
 
-    public ShellBag0X61(byte[] rawBytes)
+    public ShellBag0X61(byte[] rawBytes, int codepage=1252)
     {
         FriendlyName = "URI";
 
@@ -50,7 +50,7 @@ public class ShellBag0X61 : ShellBag
             var strSize = BitConverter.ToUInt32(rawBytes, index);
             index += 4;
 
-            var str = CodePagesEncodingProvider.Instance.GetEncoding(1252).GetString(rawBytes, index, (int) strSize);
+            var str = CodePagesEncodingProvider.Instance.GetEncoding(codepage).GetString(rawBytes, index, (int) strSize);
 
             Value = str.Replace("\0", "");
 
@@ -61,7 +61,7 @@ public class ShellBag0X61 : ShellBag
 
             if (strSize > 0)
             {
-                str = CodePagesEncodingProvider.Instance.GetEncoding(1252).GetString(rawBytes, index, (int) strSize);
+                str = CodePagesEncodingProvider.Instance.GetEncoding(codepage).GetString(rawBytes, index, (int) strSize);
 
                 UserName = str.Replace("\0", "");
                 ;
@@ -74,7 +74,7 @@ public class ShellBag0X61 : ShellBag
 
             if (strSize > 0)
             {
-                str = CodePagesEncodingProvider.Instance.GetEncoding(1252).GetString(rawBytes, index, (int) strSize);
+                str = CodePagesEncodingProvider.Instance.GetEncoding(codepage).GetString(rawBytes, index, (int) strSize);
                 index += (int) strSize;
             }
 
@@ -85,7 +85,7 @@ public class ShellBag0X61 : ShellBag
                 len1 += 1;
             }
 
-            Uri = CodePagesEncodingProvider.Instance.GetEncoding(1252).GetString(rawBytes, index, len1);
+            Uri = CodePagesEncodingProvider.Instance.GetEncoding(codepage).GetString(rawBytes, index, len1);
 
 
             index += len1 + 1;

--- a/Lnk/ShellItems/ShellBag0x74.cs
+++ b/Lnk/ShellItems/ShellBag0x74.cs
@@ -8,7 +8,7 @@ namespace Lnk.ShellItems;
 
 public class ShellBag0X74 : ShellBag
 {
-    public ShellBag0X74(byte[] rawBytes)
+    public ShellBag0X74(byte[] rawBytes, int codepage=1252)
     {
         FriendlyName = "Users Files Folder";
 
@@ -22,7 +22,7 @@ public class ShellBag0X74 : ShellBag
 
         index += 2;
 
-        var sig74 = CodePagesEncodingProvider.Instance.GetEncoding(1252).GetString(rawBytes, index, 4);
+        var sig74 = CodePagesEncodingProvider.Instance.GetEncoding(codepage).GetString(rawBytes, index, 4);
 
         if (sig74 == "CF\0\0")
         {
@@ -83,7 +83,7 @@ public class ShellBag0X74 : ShellBag
 
         index += len;
 
-        var primaryName = CodePagesEncodingProvider.Instance.GetEncoding(1252).GetString(tempBytes);
+        var primaryName = CodePagesEncodingProvider.Instance.GetEncoding(codepage).GetString(tempBytes);
 
 
         while (rawBytes[index] == 0x0)

--- a/Lnk/ShellItems/ShellBag0xc3.cs
+++ b/Lnk/ShellItems/ShellBag0xc3.cs
@@ -7,7 +7,7 @@ namespace Lnk.ShellItems;
 
 public class ShellBag0Xc3 : ShellBag
 {
-    public ShellBag0Xc3(byte[] rawBytes)
+    public ShellBag0Xc3(byte[] rawBytes, int codepage=1252)
     {
         FriendlyName = "Network location";
 
@@ -39,7 +39,7 @@ public class ShellBag0Xc3 : ShellBag
 
         index += len;
 
-        var location = CodePagesEncodingProvider.Instance.GetEncoding(1252).GetString(tempBytes);
+        var location = CodePagesEncodingProvider.Instance.GetEncoding(codepage).GetString(tempBytes);
 
         while (rawBytes[index] == 0x0)
         {

--- a/Lnk/ShellItems/ShellBagCDBurn.cs
+++ b/Lnk/ShellItems/ShellBagCDBurn.cs
@@ -8,7 +8,7 @@ namespace Lnk.ShellItems;
 
 internal class ShellBagCDBurn : ShellBag
 {
-    public ShellBagCDBurn(byte[] rawBytes)
+    public ShellBagCDBurn(byte[] rawBytes, int codepage=1252)
     {
         ShortName = string.Empty;
 
@@ -149,7 +149,7 @@ internal class ShellBagCDBurn : ShellBag
         {
             index = oldIndex + 2;
 
-            _extraBag = new ShellBag0X31(rawBytes.Skip(index).ToArray());
+            _extraBag = new ShellBag0X31(rawBytes.Skip(index).ToArray(), codepage);
 
             foreach (var ex in _extraBag.ExtensionBlocks)
             {

--- a/Lnk/VolumeInfo.cs
+++ b/Lnk/VolumeInfo.cs
@@ -24,7 +24,7 @@ public class VolumeInfo
         [Description("RAM drive")] DriveRamdisk = 6
     }
 
-    public VolumeInfo(byte[] rawBytes)
+    public VolumeInfo(byte[] rawBytes, int codepage=1252)
     {
         Size = BitConverter.ToInt32(rawBytes, 0);
         DriveType = (DriveTypes) BitConverter.ToInt32(rawBytes, 4);
@@ -40,7 +40,7 @@ public class VolumeInfo
             }
             catch (Exception)
             {
-                VolumeLabel = CodePagesEncodingProvider.Instance.GetEncoding(1252)
+                VolumeLabel = CodePagesEncodingProvider.Instance.GetEncoding(codepage)
                     ?.GetString(rawBytes, VolumeLabelOffset, rawBytes.Length - VolumeLabelOffset)
                     .Split('\0')
                     .First();
@@ -48,7 +48,7 @@ public class VolumeInfo
         }
         else
         {
-            VolumeLabel = CodePagesEncodingProvider.Instance.GetEncoding(1252)
+            VolumeLabel = CodePagesEncodingProvider.Instance.GetEncoding(codepage)
                 ?.GetString(rawBytes, VolumeLabelOffset, rawBytes.Length - VolumeLabelOffset)
                 .Split('\0')
                 .First();


### PR DESCRIPTION
such as CommonPath and LocalPath when parsing an LNK file from an OS with multibyte ANSI strings