### PR TITLE
Removing a test adapter causing the tests to fail

### DIFF
--- a/Lnk.Test/Lnk.Test.csproj
+++ b/Lnk.Test/Lnk.Test.csproj
@@ -1037,6 +1037,5 @@
     <PackageReference Include="ExtensionBlocks" Version="1.3.3" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Removing this should make the unit test part of the build / release process work again