### PR TITLE
Cap FluentAssertions to Open Licence

### DIFF
--- a/Lnk.Test/Lnk.Test.csproj
+++ b/Lnk.Test/Lnk.Test.csproj
@@ -1035,7 +1035,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ExtensionBlocks" Version="1.4.2" />
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="FluentAssertions" Version="[7.0.0,8.0.0)" />
     <PackageReference Include="NUnit" Version="4.3.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Due to the mess of [here](https://github.com/fluentassertions/fluentassertions/pull/2943). Protects against License Change 