### PR TITLE
Fix IndexOutOfRangeException in ShellBag0X31 Constructor

### DIFF
--- a/Lnk/ShellItems/ShellBag0x31.cs
+++ b/Lnk/ShellItems/ShellBag0x31.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -9,212 +9,337 @@ namespace Lnk.ShellItems;
 
 public class ShellBag0X31 : ShellBag
 {
-    public ShellBag0X31(byte[] rawBytes, int codepage=1252)
+    public ShellBag0X31(byte[] rawBytes, int codepage = 1252)
     {
         FriendlyName = "Directory";
-
-
         ExtensionBlocks = new List<IExtensionBlock>();
 
+        // Basic validation of rawBytes length
+        if (rawBytes == null || rawBytes.Length < 10)
+        {
+            Value = "Invalid or corrupted data";
+            return;
+        }
 
         var index = 2;
-        if (rawBytes.Length>0x29 && ( rawBytes[0x27] == 0x00 && rawBytes[0x28] == 0x2f && rawBytes[0x29] == 0x00 ||
-                                      rawBytes[0x24] == 0x4e && rawBytes[0x26] == 0x2f && rawBytes[0x28] == 0x41))
+
+        // ShellBag check
+        if (rawBytes.Length > 0x29 &&
+            IsValidShellBagCheck(rawBytes))
         {
-            //we have a good date
-
-            if (rawBytes[0x28] == 0x2f || rawBytes[0x26] == 0x2f || rawBytes[0x1a] == 0x2f ||
-                rawBytes[0x1c] == 0x2f)
-                // forward slash in date or N / A
+            if (HasForwardSlashInDate(rawBytes))
             {
-                //zip?
-                    
-
                 try
                 {
-                    var zip = new ShellBagZipContents(rawBytes);
-                    FriendlyName = zip.FriendlyName;
-                    LastAccessTime = zip.LastAccessTime;
+                    var _shellBag = new ShellBagZipContents(rawBytes);
+                    FriendlyName = _shellBag.FriendlyName;
+                    LastAccessTime = _shellBag.LastAccessTime;
+                    Value = _shellBag.Value;
 
-                    Value = zip.Value;
-
-                    if (Value.Contains("Unable to determine value") == false)
+                    if (!string.IsNullOrEmpty(Value) && !Value.Contains("Unable to determine value"))
                     {
                         return;
                     }
                 }
                 catch (Exception)
                 {
+                    // continue if parsing process failed!
                 }
-
-
             }
         }
 
+        // Index validation
+        if (!IsValidIndex(rawBytes, index + 9))
+        {
+            Value = "Corrupted data - insufficient bytes";
+            return;
+        }
+
+        index += 1; // skip unknown byte
         index += 1;
+        index += 4; // skip file size
 
-        //skip unknown byte
-        index += 1;
-
-        index += 4; // skip file size since always 0 for directory
-
-        LastModificationTime = Utils.ExtractDateTimeOffsetFromBytes(rawBytes.Skip(index).Take(4).ToArray());
-
+        // LastModificationTime extraction
+        if (IsValidIndex(rawBytes, index + 3))
+        {
+            LastModificationTime = Utils.ExtractDateTimeOffsetFromBytes(
+                rawBytes.Skip(index).Take(4).ToArray());
+        }
         index += 4;
-
         index += 2;
 
-        var len = 0;
+        // Find BEEF position and calculate string length
+        var beefPos = FindBeefPosition(rawBytes);
+        var strLen = CalculateStringLength(rawBytes, index, beefPos);
 
-        var beefPos = BitConverter.ToString(rawBytes).IndexOf("04-00-EF-BE", StringComparison.InvariantCulture) / 3;
-
-        beefPos = beefPos - 4; //add header back for beef
-
-        var strLen = beefPos - index;
-
-        if (strLen < 0)
+        if (strLen <= 0 || !IsValidIndex(rawBytes, index + strLen - 1))
         {
-            len = 2;
-            while (rawBytes[index + len] != 0x0)
-            {
-                len += 2;
-            }
-        }
-        else if (rawBytes[2] == 0x35|| rawBytes[2] == 0x36)
-        {
-            len = strLen;
-        }
-        else
-        {
-            while (rawBytes[index + len] != 0x0)
-            {
-                len += 1;
-            }
+            Value = "Invalid string data";
+            return;
         }
 
-        var tempBytes = new byte[len];
-        Array.Copy(rawBytes, index, tempBytes, 0, len);
-
-        index += len;
-
-        var shortName = "";
-
-        if (rawBytes[2] == 0x35 || rawBytes[2] == 0x36)
-        {
-            shortName = Encoding.Unicode.GetString(tempBytes).Trim('\0');
-        }
-        else
-        {
-            shortName = CodePagesEncodingProvider.Instance.GetEncoding(codepage).GetString(tempBytes).Trim('\0');
-        }
-
+        // String extraction
+        var shortName = ExtractShortName(rawBytes, index, strLen, codepage);
         ShortName = shortName;
-
         Value = shortName;
 
-        if (rawBytes.Length == index)
+        index += strLen;
+
+        // Boundary check after string extraction
+        if (index >= rawBytes.Length)
         {
             return;
         }
 
-        while (rawBytes[index] == 0x0)
-        {
-              
-                
-            index += 1;
+        // Skip Null bytes
+        index = SkipNullBytes(rawBytes, index);
 
-            if (rawBytes.Length == index)
-            {
-                return;
-            }
+        if (index >= rawBytes.Length)
+        {
+            return;
         }
 
-        // here is where we need to cut up the rest into extension blocks
-        var chunks = new List<byte[]>();
+        // Process Extension blocks
+        ProcessExtensionBlocks(rawBytes, index);
+    }
 
-        while (index < rawBytes.Length)
+    /// <summary>
+    /// Checks if the index is valid for the byte array
+    /// </summary>
+    private bool IsValidIndex(byte[] bytes, int index)
+    {
+        return bytes != null && index >= 0 && index < bytes.Length;
+    }
+
+    /// <summary>
+    /// Adjusted ShellBag check for byte contents
+    /// </summary>
+    private bool IsValidShellBagCheck(byte[] rawBytes)
+    {
+        try
         {
-            var subshellitemdatasize = BitConverter.ToInt16(rawBytes, index);
-
-            if (subshellitemdatasize <= 0)
-            {
-                break;
-            }
-
-            if (subshellitemdatasize == 1)
-            {
-                //some kind of separator
-                index += 2;
-            }
-            else
-            {
-                chunks.Add(rawBytes.Skip(index).Take(subshellitemdatasize).ToArray());
-                index += subshellitemdatasize;
-            }
+            return (rawBytes[0x27] == 0x00 && rawBytes[0x28] == 0x2f && rawBytes[0x29] == 0x00) ||
+                   (rawBytes[0x24] == 0x4e && rawBytes[0x26] == 0x2f && rawBytes[0x28] == 0x41);
         }
-
-        foreach (var bytes in chunks)
+        catch (IndexOutOfRangeException)
         {
-            index = 0;
-
-            var extsize = BitConverter.ToInt16(bytes, index);
-
-            if (bytes.Length < 8)
-            {
-                return;
-            }
-
-            var signature = BitConverter.ToUInt32(bytes, 0x04);
-
-            //TODO does this need to check if its a 0xbeef?? regex?
-            var block = Utils.GetExtensionBlockFromBytes(signature, bytes);
-
-            if (block.Signature.ToString("X").StartsWith("BEEF00"))
-            {
-                ExtensionBlocks.Add(block);
-            }
-
-
-            var beef0004 = block as Beef0004;
-            if (beef0004 != null)
-            {
-                Value = beef0004.LongName;
-                if (beef0004.LongName.Length == 0)
-                {
-                    Value = beef0004.LocalisedName;
-                }
-            
-            }
-
-            var beef0005 = block as Beef0005;
-            if (beef0005 != null)
-            {
-                //TODO Resolve this
-//                    foreach (var internalBag in beef0005.InternalBags)
-//                    {
-//                        ExtensionBlocks.Add(new BeefPlaceHolder(null));
-//
-//
-//                    }
-            }
-
-            index += extsize;
+            return false;
         }
     }
 
     /// <summary>
-    ///     last modified time of BagPath
+    /// Forward slash checks in date fields
+    /// </summary>
+    private bool HasForwardSlashInDate(byte[] rawBytes)
+    {
+        try
+        {
+            return rawBytes[0x28] == 0x2f || rawBytes[0x26] == 0x2f ||
+                   rawBytes[0x1a] == 0x2f || rawBytes[0x1c] == 0x2f;
+        }
+        catch (IndexOutOfRangeException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// The finds the position of the BEEF marker in the byte array
+    /// </summary>
+    private int FindBeefPosition(byte[] rawBytes)
+    {
+        try
+        {
+            var beefPos = BitConverter.ToString(rawBytes)
+                .IndexOf("04-00-EF-BE", StringComparison.InvariantCulture) / 3;
+            return beefPos > 4 ? beefPos - 4 : -1;
+        }
+        catch
+        {
+            return -1;
+        }
+    }
+
+    /// <summary>
+    /// Calculate the string length based on the BEEF position
+    /// </summary>
+    private int CalculateStringLength(byte[] rawBytes, int index, int beefPos)
+    {
+        try
+        {
+            var strLen = beefPos - index;
+
+            if (strLen < 0 || beefPos == -1)
+            {
+                // Manuel olarak null terminator ara
+                var len = rawBytes[2] == 0x35 || rawBytes[2] == 0x36 ? 2 : 1;
+                var maxSearch = Math.Min(rawBytes.Length - index, 256); // Maksimum arama limiti
+
+                while (len < maxSearch && IsValidIndex(rawBytes, index + len) && rawBytes[index + len] != 0x0)
+                {
+                    len += rawBytes[2] == 0x35 || rawBytes[2] == 0x36 ? 2 : 1;
+                }
+
+                return len;
+            }
+
+            return strLen;
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+
+    /// <summary>
+    /// Extracts the short name from the byte array
+    /// </summary>
+    private string ExtractShortName(byte[] rawBytes, int index, int length, int codepage)
+    {
+        try
+        {
+            if (length <= 0 || !IsValidIndex(rawBytes, index + length - 1))
+            {
+                return string.Empty;
+            }
+
+            var tempBytes = new byte[length];
+            Array.Copy(rawBytes, index, tempBytes, 0, length);
+
+            if (rawBytes.Length > 2 && (rawBytes[2] == 0x35 || rawBytes[2] == 0x36))
+            {
+                return Encoding.Unicode.GetString(tempBytes).Trim('\0');
+            }
+            else
+            {
+                var encoding = CodePagesEncodingProvider.Instance.GetEncoding(codepage);
+                return encoding?.GetString(tempBytes).Trim('\0') ?? string.Empty;
+            }
+        }
+        catch
+        {
+            return "Corrupted string data";
+        }
+    }
+
+    /// <summary>
+    /// Skip null bytes in the byte array
+    /// </summary>
+    private int SkipNullBytes(byte[] rawBytes, int startIndex)
+    {
+        var index = startIndex;
+        while (IsValidIndex(rawBytes, index) && rawBytes[index] == 0x0)
+        {
+            index++;
+        }
+        return index;
+    }
+
+    /// <summary>
+    /// Processes the extension blocks from the byte array
+    /// </summary>
+    private void ProcessExtensionBlocks(byte[] rawBytes, int startIndex)
+    {
+        try
+        {
+            var chunks = new List<byte[]>();
+            var index = startIndex;
+
+            while (IsValidIndex(rawBytes, index + 1))
+            {
+                var subshellitemdatasize = BitConverter.ToInt16(rawBytes, index);
+
+                if (subshellitemdatasize <= 0)
+                {
+                    break;
+                }
+
+                if (subshellitemdatasize == 1)
+                {
+                    index += 2;
+                }
+                else if (IsValidIndex(rawBytes, index + subshellitemdatasize - 1))
+                {
+                    chunks.Add(rawBytes.Skip(index).Take(subshellitemdatasize).ToArray());
+                    index += subshellitemdatasize;
+                }
+                else
+                {
+                    break; // Out of bounds, stop processing
+                }
+            }
+
+            ProcessChunks(chunks);
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Extension block processing error: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Processes the chunks of byte arrays to extract extension blocks
+    /// </summary>
+    private void ProcessChunks(List<byte[]> chunks)
+    {
+        foreach (var bytes in chunks)
+        {
+            try
+            {
+                if (bytes.Length < 8)
+                {
+                    continue;
+                }
+
+                var extsize = BitConverter.ToInt16(bytes, 0);
+                var signature = BitConverter.ToUInt32(bytes, 0x04);
+
+                var block = Utils.GetExtensionBlockFromBytes(signature, bytes);
+
+                if (block?.Signature.ToString("X").StartsWith("BEEF00") == true)
+                {
+                    ExtensionBlocks.Add(block);
+                }
+
+                UpdateValueFromExtensionBlock(block);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Chunk processing error: {ex.Message}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Updates the Value property based on the extension block
+    /// </summary>
+    private void UpdateValueFromExtensionBlock(IExtensionBlock block)
+    {
+        try
+        {
+            if (block is Beef0004 beef0004)
+            {
+                Value = !string.IsNullOrEmpty(beef0004.LongName) ?
+                        beef0004.LongName : beef0004.LocalisedName;
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Value update error: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// last modified time of BagPath
     /// </summary>
     public DateTimeOffset? LastModificationTime { get; set; }
 
-
     /// <summary>
-    ///     Last access time of BagPath
+    /// Last access time of BagPath
     /// </summary>
     public DateTimeOffset? LastAccessTime { get; set; }
 
-    public string ShortName { get; }
-
+    public string ShortName { get; private set; } = string.Empty;
 
     public override string ToString()
     {
@@ -222,7 +347,7 @@ public class ShellBag0X31 : ShellBag
 
         sb.AppendLine(base.ToString());
 
-        if (ShortName.Length > 0)
+        if (!string.IsNullOrEmpty(ShortName))
         {
             sb.AppendLine($"Short name: {ShortName}");
         }


### PR DESCRIPTION
**The file that has issue (malicious lnk file - zip password: infected):** https://api.docguard.io/Downloads/acce9136-dd3f-4eca-8590-7a7405831fb9/656a47064ee26b49204412889e7f2ff4c98ebb8579e01cca84679ff31688e6ea.zip
 
The ShellBag0X31 constructor was throwing IndexOutOfRangeException when processing corrupted or malformed LNK files. This occurred due to unsafe array access operations without proper bounds checking, causing the application to crash when encountering invalid data. Error Details:
System.Exception: Error processing file - the error was (Index was outside the bounds of the array.)
  at Lnk.ShellItems.ShellBag0X31.ShellBag0X31(byte[], int) in ShellBag0x31.cs
  
Root Cause
The original implementation had several unsafe array access patterns:

- Direct array indexing without bounds validation (e.g., rawBytes[0x27], rawBytes[0x28])
- Unsafe string length calculation when searching for null terminators
- No validation before copying byte arrays
- Unchecked extension block processing that could exceed array boundaries
- Missing null checks for input parameters

Fixes

- Safe shellbag content detection: Wrapped byte validation logic in try-catch blocks
- Protected string extraction: Added length validation before string operations
- Controlled BEEF pattern search: Added exception handling for BitConverter operations
- Limited search operations: Implemented maximum search limits to prevent infinite loops
- Graceful extension block processing: Each extension block is processed with individual error handling


